### PR TITLE
fix MetroColorPicker不能使用Background作为CurrentColor的问题

### DIFF
--- a/src/AduSkin/Controls/Metro/MetroColorPicker.xaml.cs
+++ b/src/AduSkin/Controls/Metro/MetroColorPicker.xaml.cs
@@ -54,7 +54,7 @@ namespace AduSkin.Controls.Metro
         public MetroColorPicker()
         {
             InitializeComponent();
-            Loaded += delegate { Initialize(Background == null ? new HsbaColor(0.0, 1.0, 1.0, 1.0) : new HsbaColor(Background)); };
+            Loaded += delegate { Initialize(); };
         }
 
         public MetroColorPicker(string hexColor)
@@ -71,8 +71,12 @@ namespace AduSkin.Controls.Metro
 
         public Action ColorPickerClosed { get; set; }
 
-        private void Initialize(HsbaColor hsbaColor)
+        private void Initialize(HsbaColor hsbaColor = null)
         {
+            if (hsbaColor == null)
+            {
+                hsbaColor = Background == null ? new HsbaColor(0.0, 1.0, 1.0, 1.0) : new HsbaColor(Background);
+            }
             // 绑定主题
             Utility.Refresh(this);
 


### PR DESCRIPTION
MetroColorPicker调用无参构造函数时，Backound始终为null，无法被设置为currentColor。
修改为在Initialize方法中设置。