### PR TITLE
1、在AduSkin、AduVideoPlayer两个项目的 AssemblyInfo 中加入 XmlnsDefinition、Xmlns…

### DIFF
--- a/src/AduSkin/Controls/Metro/AduWindow.cs
+++ b/src/AduSkin/Controls/Metro/AduWindow.cs
@@ -2,6 +2,7 @@ using AduSkin.Themes;
 using AduSkin.Utility.Element;
 using System;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -11,6 +12,7 @@ namespace AduSkin.Controls.Metro
 {
    public partial class AduWindow : Window
    {
+      private Button _btnMinimized, _btnMaximized, _btnNormal, _btnClose;
       public static readonly DependencyProperty IsSubWindowShowProperty = ElementBase.Property<AduWindow, bool>("IsSubWindowShowProperty", false);
       public static readonly DependencyProperty MenuProperty = ElementBase.Property<AduWindow, object>("MenuProperty", null);
       public static readonly new DependencyProperty BorderBrushProperty = ElementBase.Property<AduWindow, Brush>("BorderBrushProperty");
@@ -92,11 +94,61 @@ namespace AduSkin.Controls.Metro
          Utility.Refresh(this);
       }
 
+      /// <summary>在派生类中重写时，每当应用程序代码或内部进程调用 <see cref="FrameworkElement.ApplyTemplate" /> 时调用。</summary>
+      public override void OnApplyTemplate()
+      {
+         _btnMinimized = (Button)GetTemplateChild("minimizedButton");
+         _btnMaximized = (Button)GetTemplateChild("maximizedButton");
+         _btnNormal = (Button)GetTemplateChild("normalButton");
+         _btnClose = (Button)GetTemplateChild("closeButton");
+         BindSystemButtonEvent();
+         base.OnApplyTemplate();
+      }
+
       static AduWindow()
       {
          ElementBase.DefaultStyle<AduWindow>(DefaultStyleKeyProperty);
       }
 
+      /// <summary>给系统按钮绑定事件</summary>
+      private void BindSystemButtonEvent()
+      {
+         _btnMinimized.Click += Minimized;
+         _btnMaximized.Click += Maximized;
+         _btnNormal.Click += Normal;
+         _btnClose.Click += Close;
+      }
 
+      /// <summary>窗口最小化按钮事件</summary>
+      /// <param name="sender"></param>
+      /// <param name="e"></param>
+      private void Minimized(object sender, RoutedEventArgs e)
+      {
+         GetWindow(sender as FrameworkElement).WindowState = WindowState.Minimized;
+      }
+
+      /// <summary>窗口最大化按钮事件</summary>
+      /// <param name="sender"></param>
+      /// <param name="e"></param>
+      private void Maximized(object sender, RoutedEventArgs e)
+      {
+         GetWindow(sender as FrameworkElement).WindowState = WindowState.Maximized;
+      }
+
+      /// <summary>还原窗口按钮事件</summary>
+      /// <param name="sender"></param>
+      /// <param name="e"></param>
+      private void Normal(object sender, RoutedEventArgs e)
+      {
+         Window.GetWindow(sender as FrameworkElement).WindowState = WindowState.Normal;
+      }
+
+      /// <summary>关闭窗口按钮事件</summary>
+      /// <param name="sender"></param>
+      /// <param name="e"></param>
+      private void Close(object sender, RoutedEventArgs e)
+      {
+         Window.GetWindow(sender as FrameworkElement).Close();
+      }
    }
 }

--- a/src/AduSkin/Controls/Metro/MetroWindow.cs
+++ b/src/AduSkin/Controls/Metro/MetroWindow.cs
@@ -2,93 +2,147 @@ using AduSkin.Themes;
 using AduSkin.Utility.Element;
 using System;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 
 namespace AduSkin.Controls.Metro
 {
-    public class MetroWindow : Window
-    {
-        public static readonly DependencyProperty IsSubWindowShowProperty = ElementBase.Property<MetroWindow, bool>("IsSubWindowShowProperty", false);
-        public static readonly DependencyProperty MenuProperty = ElementBase.Property<MetroWindow, object>("MenuProperty", null);
-        public static readonly new DependencyProperty BorderBrushProperty = ElementBase.Property<MetroWindow, Brush>("BorderBrushProperty");
-        public static readonly DependencyProperty TitleForegroundProperty = ElementBase.Property<MetroWindow, Brush>("TitleForegroundProperty");
-        public static readonly DependencyProperty TitleFontSizeProperty = ElementBase.Property<MetroWindow, FontSizeConverter>("TitleFontSizeProperty");
-        public static readonly DependencyProperty SysButtonColorProperty = ElementBase.Property<MetroWindow, Brush>("SysButtonColorProperty");
+   public class MetroWindow : Window
+   {
+      private Button _btnMinimized, _btnMaximized, _btnNormal, _btnClose;
+      public static readonly DependencyProperty IsSubWindowShowProperty = ElementBase.Property<MetroWindow, bool>("IsSubWindowShowProperty", false);
+      public static readonly DependencyProperty MenuProperty = ElementBase.Property<MetroWindow, object>("MenuProperty", null);
+      public static readonly new DependencyProperty BorderBrushProperty = ElementBase.Property<MetroWindow, Brush>("BorderBrushProperty");
+      public static readonly DependencyProperty TitleForegroundProperty = ElementBase.Property<MetroWindow, Brush>("TitleForegroundProperty");
+      public static readonly DependencyProperty TitleFontSizeProperty = ElementBase.Property<MetroWindow, FontSizeConverter>("TitleFontSizeProperty");
+      public static readonly DependencyProperty SysButtonColorProperty = ElementBase.Property<MetroWindow, Brush>("SysButtonColorProperty");
 
-        public bool IsSubWindowShow { get { return (bool)GetValue(IsSubWindowShowProperty); } set { SetValue(IsSubWindowShowProperty, value); GoToState(); } }
-        public object Menu { get { return GetValue(MenuProperty); } set { SetValue(MenuProperty, value); } }
-        public new Brush BorderBrush { get { return (Brush)GetValue(BorderBrushProperty); } set { SetValue(BorderBrushProperty, value); BorderBrushChange(value); } }
-        public Brush TitleForeground { get { return (Brush)GetValue(TitleForegroundProperty); } set { SetValue(TitleForegroundProperty, value); } }
-        public Brush SysButtonColor { get { return (Brush)GetValue(SysButtonColorProperty); } set { SetValue(SysButtonColorProperty, value); } }
-        public FontSizeConverter TitleFontSize { get { return (FontSizeConverter)GetValue(TitleFontSizeProperty); } set { SetValue(TitleFontSizeProperty, value); } }
-        void BorderBrushChange(Brush brush)
-        {
-            if (IsLoaded)
+      public bool IsSubWindowShow { get { return (bool)GetValue(IsSubWindowShowProperty); } set { SetValue(IsSubWindowShowProperty, value); GoToState(); } }
+      public object Menu { get { return GetValue(MenuProperty); } set { SetValue(MenuProperty, value); } }
+      public new Brush BorderBrush { get { return (Brush)GetValue(BorderBrushProperty); } set { SetValue(BorderBrushProperty, value); BorderBrushChange(value); } }
+      public Brush TitleForeground { get { return (Brush)GetValue(TitleForegroundProperty); } set { SetValue(TitleForegroundProperty, value); } }
+      public Brush SysButtonColor { get { return (Brush)GetValue(SysButtonColorProperty); } set { SetValue(SysButtonColorProperty, value); } }
+      public FontSizeConverter TitleFontSize { get { return (FontSizeConverter)GetValue(TitleFontSizeProperty); } set { SetValue(TitleFontSizeProperty, value); } }
+      void BorderBrushChange(Brush brush)
+      {
+         if (IsLoaded)
+         {
+            Theme.Switch(this);
+         }
+      }
+
+      void GoToState()
+      {
+         ElementBase.GoToState(this, IsSubWindowShow ? "Enabled" : "Disable");
+      }
+
+      public object ReturnValue { get; set; } //= null;
+      public bool EscClose { get; set; } //= false;
+
+      protected override void OnInitialized(EventArgs e)
+      {
+         base.OnInitialized(e);
+
+         WindowStartupLocation = WindowStartupLocation.CenterScreen;
+         AllowsTransparency = false;
+         if (WindowStyle == WindowStyle.None)
+         {
+            WindowStyle = WindowStyle.SingleBorderWindow;
+         }
+      }
+
+      public MetroWindow()
+      {
+         // 修复WindowChrome导致的窗口大小错误
+         var sizeToContent = SizeToContent.Manual;
+         Loaded += (ss, ee) =>
+         {
+            sizeToContent = SizeToContent;
+         };
+         ContentRendered += (ss, ee) =>
+         {
+            SizeToContent = SizeToContent.Manual;
+            Width = ActualWidth;
+            Height = ActualHeight;
+            SizeToContent = sizeToContent;
+         };
+
+         KeyUp += delegate (object sender, KeyEventArgs e)
+         {
+            if (e.Key == Key.Escape && EscClose)
             {
-                Theme.Switch(this);
+               Close();
             }
-        }
-
-        void GoToState()
-        {
-            ElementBase.GoToState(this, IsSubWindowShow ? "Enabled" : "Disable");
-        }
-
-        public object ReturnValue { get; set; } //= null;
-        public bool EscClose { get; set; } //= false;
-
-        protected override void OnInitialized(EventArgs e)
-        {
-            base.OnInitialized(e);
-
-            WindowStartupLocation = WindowStartupLocation.CenterScreen;
-            AllowsTransparency = false;
-            if (WindowStyle == WindowStyle.None)
-            {
-                WindowStyle = WindowStyle.SingleBorderWindow;
-            }
-        }
-
-        public MetroWindow()
-        {
-            // 修复WindowChrome导致的窗口大小错误
-            var sizeToContent = SizeToContent.Manual;
-            Loaded += (ss, ee) =>
-            {
-                sizeToContent = SizeToContent;
-            };
-            ContentRendered += (ss, ee) =>
-            {
-                SizeToContent = SizeToContent.Manual;
-                Width = ActualWidth;
-                Height = ActualHeight;
-                SizeToContent = sizeToContent;
-            };
-
-            KeyUp += delegate (object sender, KeyEventArgs e)
-            {
-                if (e.Key == Key.Escape && EscClose)
-                {
-                    Close();
-                }
-            };
-            StateChanged += delegate
+         };
+         StateChanged += delegate
+           {
+              if (ResizeMode == ResizeMode.CanMinimize || ResizeMode == ResizeMode.NoResize)
               {
-                  if (ResizeMode == ResizeMode.CanMinimize || ResizeMode == ResizeMode.NoResize)
-                  {
-                      if (WindowState == WindowState.Maximized)
-                      {
-                          WindowState = WindowState.Normal;
-                      }
-                  }
-              };
-            Utility.Refresh(this);
-        }
+                 if (WindowState == WindowState.Maximized)
+                 {
+                    WindowState = WindowState.Normal;
+                 }
+              }
+           };
+         Utility.Refresh(this);
+      }
 
-        static MetroWindow()
-        {
-            ElementBase.DefaultStyle<MetroWindow>(DefaultStyleKeyProperty);
-        }
-    }
+      /// <summary>在派生类中重写时，每当应用程序代码或内部进程调用 <see cref="FrameworkElement.ApplyTemplate" /> 时调用。</summary>
+      public override void OnApplyTemplate()
+      {
+         _btnMinimized = (Button)GetTemplateChild("minimizedButton");
+         _btnMaximized = (Button)GetTemplateChild("maximizedButton");
+         _btnNormal = (Button)GetTemplateChild("normalButton");
+         _btnClose = (Button)GetTemplateChild("closeButton");
+         BindSystemButtonEvent();
+         base.OnApplyTemplate();
+      }
+
+      static MetroWindow()
+      {
+         ElementBase.DefaultStyle<MetroWindow>(DefaultStyleKeyProperty);
+      }
+
+      /// <summary>给系统按钮绑定事件</summary>
+      private void BindSystemButtonEvent()
+      {
+         _btnMinimized.Click += Minimized;
+         _btnMaximized.Click += Maximized;
+         _btnNormal.Click += Normal;
+         _btnClose.Click += Close;
+      }
+
+      /// <summary>窗口最小化按钮事件</summary>
+      /// <param name="sender"></param>
+      /// <param name="e"></param>
+      private void Minimized(object sender, RoutedEventArgs e)
+      {
+         GetWindow(sender as FrameworkElement).WindowState = WindowState.Minimized;
+      }
+
+      /// <summary>窗口最大化按钮事件</summary>
+      /// <param name="sender"></param>
+      /// <param name="e"></param>
+      private void Maximized(object sender, RoutedEventArgs e)
+      {
+         GetWindow(sender as FrameworkElement).WindowState = WindowState.Maximized;
+      }
+
+      /// <summary>还原窗口按钮事件</summary>
+      /// <param name="sender"></param>
+      /// <param name="e"></param>
+      private void Normal(object sender, RoutedEventArgs e)
+      {
+         Window.GetWindow(sender as FrameworkElement).WindowState = WindowState.Normal;
+      }
+
+      /// <summary>关闭窗口按钮事件</summary>
+      /// <param name="sender"></param>
+      /// <param name="e"></param>
+      private void Close(object sender, RoutedEventArgs e)
+      {
+         Window.GetWindow(sender as FrameworkElement).Close();
+      }
+   }
 }

--- a/src/AduSkin/Properties/AssemblyInfo.cs
+++ b/src/AduSkin/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+using System.Windows;
+using System.Windows.Markup;
 
 [assembly:ThemeInfo(
     ResourceDictionaryLocation.None, //主题特定资源词典所处位置
@@ -8,3 +9,23 @@
                                       //(当资源未在页面
                                       //、应用程序或任何主题专用资源字典中找到时使用)
 )]
+
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Commen")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Controls")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Controls.Attach")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Controls.Converter")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Controls.Data")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Controls.Data.Args")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Controls.Expression.Drawing")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Controls.Helper")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Controls.Metro")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Controls.Tools")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Controls.Tools.Extension")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Controls.Tools.Interop")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Interactivity")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Utility.AduMethod")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Utility.Computer")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Utility.Element")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Utility.Extend")]
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduSkin.Utility.Media")]
+[assembly: XmlnsPrefix("https://github.com/aduskin", "adu")]

--- a/src/AduSkin/Themes/Metro/AduWindow.xaml
+++ b/src/AduSkin/Themes/Metro/AduWindow.xaml
@@ -100,7 +100,6 @@
                                 <StackPanel Visibility="{TemplateBinding SysButtonVisible}" HorizontalAlignment="Right" Orientation="Horizontal" Margin="{TemplateBinding SysButtonMargin}" VerticalAlignment="Top" Shell:WindowChrome.IsHitTestVisibleInChrome="True">
                                     <Button
                                             x:Name="minimizedButton"
-                                            Click="Minimized"
                                             Style="{StaticResource buttonStyle}">
                                         <Button.Content>
                                             <Path
@@ -113,7 +112,6 @@
                                     </Button>
                                     <Button
                                             x:Name="maximizedButton"
-                                            Click="Maximized"
                                             Style="{StaticResource buttonStyle}">
                                         <Button.Content>
                                             <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
@@ -123,7 +121,6 @@
                                     </Button>
                                     <Button
                                             x:Name="normalButton"
-                                            Click="Normal"
                                             Style="{StaticResource buttonStyle}">
                                         <Button.Content>
                                             <Grid
@@ -136,7 +133,6 @@
                                     </Button>
                                     <Button
                                             x:Name="closeButton"
-                                            Click="Close"
                                             Style="{StaticResource buttonStyle}">
                                         <Button.Content>
                                             <Grid HorizontalAlignment="Center" VerticalAlignment="Center">

--- a/src/AduSkin/Themes/Metro/MetroWindow.xaml
+++ b/src/AduSkin/Themes/Metro/MetroWindow.xaml
@@ -133,26 +133,26 @@
                         </Grid>
                         <Grid Grid.Column="3" x:Name="sysButton" Shell:WindowChrome.IsHitTestVisibleInChrome="True">
                            <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
-                              <Button x:Name="minimizedButton" Click="Minimized" Style="{StaticResource buttonStyle}">
+                              <Button x:Name="minimizedButton" Style="{StaticResource buttonStyle}">
                                  <Button.Content>
                                     <Path Width="11" Height="2" Data="{StaticResource Icon_SysMin}" Fill="{TemplateBinding SysButtonColor}"  Stretch="Fill" />
                                  </Button.Content>
                               </Button>
-                              <Button x:Name="maximizedButton" Click="Maximized" Foreground="{TemplateBinding TitleForeground}" Style="{StaticResource buttonStyle}">
+                              <Button x:Name="maximizedButton" Foreground="{TemplateBinding TitleForeground}" Style="{StaticResource buttonStyle}">
                                  <Button.Content>
                                     <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
                                        <Path Width="11" Height="11" Margin="0,0,0,0" Shape.Fill="{TemplateBinding SysButtonColor}" Shape.Stretch="Fill" Path.Data="{StaticResource Icon_SysMax}" />
                                     </Grid>
                                  </Button.Content>
                               </Button>
-                              <Button x:Name="normalButton" Click="Normal" Foreground="{TemplateBinding TitleForeground}" Style="{StaticResource buttonStyle}">
+                              <Button x:Name="normalButton" Foreground="{TemplateBinding TitleForeground}" Style="{StaticResource buttonStyle}">
                                  <Button.Content>
                                     <Grid Margin="0,2,3,0" HorizontalAlignment="Center" VerticalAlignment="Center">
                                        <Path  Width="11" Height="11" Margin="0,0,0,0" Shape.Fill="{TemplateBinding SysButtonColor}" Shape.Stretch="Fill" Path.Data="{StaticResource Icon_SystemRestore}" />
                                     </Grid>
                                  </Button.Content>
                               </Button>
-                              <Button x:Name="closeButton" Click="Close" Foreground="{TemplateBinding TitleForeground}" Style="{StaticResource buttonStyle}">
+                              <Button x:Name="closeButton" Foreground="{TemplateBinding TitleForeground}" Style="{StaticResource buttonStyle}">
                                  <Button.Content>
                                     <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
                                        <Path  Width="11" Height="11" Margin="0,0,0,0" Shape.Fill="{TemplateBinding SysButtonColor}" Shape.Stretch="Fill" Path.Data="{StaticResource Icon_SystemClose}" />

--- a/src/AduVideoPlayer/Properties/AssemblyInfo.cs
+++ b/src/AduVideoPlayer/Properties/AssemblyInfo.cs
@@ -1,3 +1,7 @@
-﻿using System.Windows;
+using System.Windows;
+using System.Windows.Markup;
 
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
+
+[assembly: XmlnsDefinition("https://github.com/aduskin", "AduVideoPlayer.Controls")]
+[assembly: XmlnsPrefix("https://github.com/aduskin", "adu")]


### PR DESCRIPTION
…Prefix 特征，在 XAML 中注册可以改用 xmlns:adu="https://github.com/aduskin" 的形式。

2、AduWindow、MetroWindow 重写 OnApplyTemplate 来给系统按钮绑定事件，而不用在主题代码中去写事件。